### PR TITLE
Fixes #2

### DIFF
--- a/00-deploy-gke.sh
+++ b/00-deploy-gke.sh
@@ -5,14 +5,14 @@ GCP_ZONE=$3
 
 create_k8s_cluster(){
   gcloud beta container --project "$PROJECT_NAME" clusters create "$K8S_CLUSTER_NAME" --zone "$GCP_ZONE" --no-enable-basic-auth \
-  --cluster-version "1.21.9-gke.1001" --release-channel "None" --machine-type "e2-standard-8" --image-type "COS_CONTAINERD" \
+  --release-channel "stable" --machine-type "e2-standard-8" --image-type "COS_CONTAINERD" \
   --disk-type "pd-standard" --disk-size "100" --metadata disable-legacy-endpoints=true \
   --scopes "https://www.googleapis.com/auth/devstorage.read_only","https://www.googleapis.com/auth/logging.write","https://www.googleapis.com/auth/monitoring","https://www.googleapis.com/auth/servicecontrol","https://www.googleapis.com/auth/service.management.readonly","https://www.googleapis.com/auth/trace.append" \
   --max-pods-per-node "110" --num-nodes "3" --logging=SYSTEM,WORKLOAD --monitoring=SYSTEM --enable-ip-alias \
-  --network "projects/$PROJECT_NAME/global/networks/default" --subnetwork "projects/$PROJECT_NAME/regions/us-central1/subnetworks/default" \
+  --network "projects/$PROJECT_NAME/global/networks/default" \
   --no-enable-intra-node-visibility --default-max-pods-per-node "110" --no-enable-master-authorized-networks --addons HorizontalPodAutoscaling,HttpLoadBalancing,GcePersistentDiskCsiDriver \
   --enable-autoupgrade --enable-autorepair --max-surge-upgrade 1 --max-unavailable-upgrade 0 --enable-shielded-nodes
-#  --node-locations "$GCP_ZONE"
+#  --node-locations "$GCP_ZONE" --subnetwork "projects/$PROJECT_NAME/regions/$GCP_ZONE/subnetworks/default" --cluster-version "1.21.11-gke.1900"
 }
 
 authenticate_kubectl(){


### PR DESCRIPTION
removed the flags `--subnetwork` and `--cluster-version` from `gcloud beta container clusters create`.

this allows `gcloud` command to create the GKE cluster at whatever version is on the `stable` release channel. it also does not specify any subnetwork, allowing GKE cluster to be deployed into whichever region the user desires.  